### PR TITLE
Switch to EFS mount

### DIFF
--- a/inventories/staging
+++ b/inventories/staging
@@ -1,8 +1,8 @@
 [geoservers]
-172.0.1.65 ansible_user=admin
+geoserver-stage.mitlib.net ansible_user=admin
 
 [solrs]
-172.0.1.64 ansible_user=admin
+solr-stage.mitlib.net ansible_user=admin
 
 [staging:children]
 geoservers

--- a/roles/geoserver/vars/main.yml
+++ b/roles/geoserver/vars/main.yml
@@ -1,5 +1,5 @@
 geoserver_version: 2.15.1
 geoserver_minor_version: "2.15"
-geoserver_data: /var/geoserver/data
+geoserver_data: /mnt/geoserver/geoserver/data
 geoserver_home: /opt/geoserver
 geoserver_user: admin

--- a/roles/solr/vars/main.yml
+++ b/roles/solr/vars/main.yml
@@ -1,3 +1,3 @@
-solr_version: 7.7.1
-solr_home: /var/solr/data
+solr_version: 7.7.2
+solr_home: /mnt/solr/solr/data
 solr_install: /opt/solr


### PR DESCRIPTION
This will switch to using the EFS mount as the data directory for both
Solr and GeoServer. The applications themselves are still written to the
attached EC2 block storage. This is just the persistent data
directories.